### PR TITLE
issue #33 collectionview doesn't fill screen

### DIFF
--- a/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
+++ b/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -45,8 +45,9 @@
 		9A0F7CA5195A0B9500271D1D /* RZZoomPushAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F7C90195A0B9500271D1D /* RZZoomPushAnimationController.m */; };
 		9A0F7CA6195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F7C93195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m */; };
 		9A0F7CA7195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */; };
+		E14D80001BFFC419009BDB4F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E1A3E92C1BFD0C57003F3681 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1A3E92B1BFD0C57003F3681 /* Launch Screen.storyboard */; };
-		E14D80001BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E14D7FFF1BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m */; };
+		E1B7453A1C03BBC5004514ED /* NSObject+RZTransitionsViewHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B745391C03BBC5004514ED /* NSObject+RZTransitionsViewHelpers.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,8 +130,9 @@
 		9A0F7C93195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+RZTransitionsFastImageBlur.m"; sourceTree = "<group>"; };
 		9A0F7C94195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+RZTransitionsSnapshotHelpers.h"; sourceTree = "<group>"; };
 		9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+RZTransitionsSnapshotHelpers.m"; sourceTree = "<group>"; };
-		E1A3E92B1BFD0C57003F3681 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		E14D80011BFFC460009BDB4F /* NSObject+RZTransitionsViewHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+RZTransitionsViewHelpers.h"; sourceTree = "<group>"; };
+		E1A3E92B1BFD0C57003F3681 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		E1B745391C03BBC5004514ED /* NSObject+RZTransitionsViewHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+RZTransitionsViewHelpers.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -354,7 +356,7 @@
 				9A0F7C94195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.h */,
 				9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */,
 				E14D80011BFFC460009BDB4F /* NSObject+RZTransitionsViewHelpers.h */,
-				E14D7FFF1BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m */,
+				E1B745391C03BBC5004514ED /* NSObject+RZTransitionsViewHelpers.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -443,7 +445,7 @@
 				};
 			};
 			buildConfigurationList = 833E369F184E29C300A0326A /* Build configuration list for PBXProject "RZTransitions-Demo" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -497,7 +499,8 @@
 				9A0F7C9C195A0B9500271D1D /* RZVerticalSwipeInteractionController.m in Sources */,
 				833E36E9184E5A9A00A0326A /* RZTransitionsDemoAppDelegate.m in Sources */,
 				9A0F7C9E195A0B9500271D1D /* RZCardSlideAnimationController.m in Sources */,
-				E14D80001BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m in Sources */,
+				E1B7453A1C03BBC5004514ED /* NSObject+RZTransitionsViewHelpers.m in Sources */,
+				E14D80001BFFC419009BDB4F /* (null) in Sources */,
 				9A0F7C9A195A0B9500271D1D /* RZOverscrollInteractionController.m in Sources */,
 				9A0F7C9B195A0B9500271D1D /* RZPinchInteractionController.m in Sources */,
 				9A0F7C98195A0B9500271D1D /* RZBaseSwipeInteractionController.m in Sources */,

--- a/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
+++ b/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9A0F7CA6195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F7C93195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m */; };
 		9A0F7CA7195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */; };
 		E1A3E92C1BFD0C57003F3681 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1A3E92B1BFD0C57003F3681 /* Launch Screen.storyboard */; };
+		E14D80001BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E14D7FFF1BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +130,7 @@
 		9A0F7C94195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+RZTransitionsSnapshotHelpers.h"; sourceTree = "<group>"; };
 		9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+RZTransitionsSnapshotHelpers.m"; sourceTree = "<group>"; };
 		E1A3E92B1BFD0C57003F3681 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		E14D80011BFFC460009BDB4F /* NSObject+RZTransitionsViewHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+RZTransitionsViewHelpers.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -351,6 +353,8 @@
 				9A0F7C93195A0B9500271D1D /* UIImage+RZTransitionsFastImageBlur.m */,
 				9A0F7C94195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.h */,
 				9A0F7C95195A0B9500271D1D /* UIImage+RZTransitionsSnapshotHelpers.m */,
+				E14D80011BFFC460009BDB4F /* NSObject+RZTransitionsViewHelpers.h */,
+				E14D7FFF1BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -493,6 +497,7 @@
 				9A0F7C9C195A0B9500271D1D /* RZVerticalSwipeInteractionController.m in Sources */,
 				833E36E9184E5A9A00A0326A /* RZTransitionsDemoAppDelegate.m in Sources */,
 				9A0F7C9E195A0B9500271D1D /* RZCardSlideAnimationController.m in Sources */,
+				E14D80001BFFC419009BDB4F /* NSObject+RZTransitionsViewHelpers.m in Sources */,
 				9A0F7C9A195A0B9500271D1D /* RZOverscrollInteractionController.m in Sources */,
 				9A0F7C9B195A0B9500271D1D /* RZPinchInteractionController.m in Sources */,
 				9A0F7C98195A0B9500271D1D /* RZBaseSwipeInteractionController.m in Sources */,

--- a/RZTransitions/Transitions/RZZoomBlurAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomBlurAnimationController.m
@@ -27,6 +27,8 @@
 //
 
 #import "RZZoomBlurAnimationController.h"
+
+#import "NSObject+RZTransitionsViewHelpers.h"
 #import "UIImage+RZTransitionsFastImageBlur.h"
 #import <objc/runtime.h>
 
@@ -77,8 +79,8 @@ static char kRZZoomBlurImageAssocKey;
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     UIView *container = [transitionContext containerView];
 
-    UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
-    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+    UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
+    UIView *toView = [(NSObject *)transitionContext rzt_toView];
 
     toView.userInteractionEnabled = YES;
 

--- a/RZTransitions/Transitions/RZZoomPushAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomPushAnimationController.m
@@ -38,51 +38,50 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {    
-    UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
-    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+    UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
     UIView *container = [transitionContext containerView];
     
     if ( self.isPositiveAnimation ) {
-        [container insertSubview:toViewController.view belowSubview:fromViewController.view];
-        toViewController.view.transform = CGAffineTransformMakeScale(1.0 - kRZPushScaleChangePct, 1.0 - kRZPushScaleChangePct);
+        toView.frame = container.frame;
+        [container insertSubview:toView belowSubview:fromView];
+        toView.transform = CGAffineTransformMakeScale(1.0 - kRZPushScaleChangePct, 1.0 - kRZPushScaleChangePct);
 
-        //! TODO: We shouldn't really call viewWillAppear here.
-        [toViewController viewWillAppear:YES];
         [UIView animateWithDuration:kRZPushTransitionTime
                               delay:0
                             options:UIViewAnimationOptionCurveEaseOut
                          animations:^{
-                             toViewController.view.transform = CGAffineTransformIdentity;
-                             fromViewController.view.transform = CGAffineTransformMakeScale(1.0 + kRZPushScaleChangePct, 1.0 + kRZPushScaleChangePct);
-                             fromViewController.view.alpha = 0.0f;
+                             toView.transform = CGAffineTransformIdentity;
+                             fromView.transform = CGAffineTransformMakeScale(1.0 + kRZPushScaleChangePct, 1.0 + kRZPushScaleChangePct);
+                             fromView.alpha = 0.0f;
                          }
                          completion:^(BOOL finished) {
-                             toViewController.view.transform = CGAffineTransformIdentity;
-                             fromViewController.view.transform = CGAffineTransformIdentity;
-                             fromViewController.view.alpha = 1.0f;
+                             toView.transform = CGAffineTransformIdentity;
+                             fromView.transform = CGAffineTransformIdentity;
+                             fromView.alpha = 1.0f;
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }
     else {
         if (transitionContext.presentationStyle == UIModalPresentationNone) {
-            [container insertSubview:toViewController.view belowSubview:fromViewController.view];
+            [container insertSubview:toView belowSubview:fromView];
         }
-        toViewController.view.transform = CGAffineTransformMakeScale(1.0 + kRZPushScaleChangePct, 1.0 + kRZPushScaleChangePct);
-        toViewController.view.alpha = 0.0f;
+        toView.transform = CGAffineTransformMakeScale(1.0 + kRZPushScaleChangePct, 1.0 + kRZPushScaleChangePct);
+        toView.alpha = 0.0f;
         
-        [toViewController viewWillAppear:YES];
         [UIView animateWithDuration:kRZPushTransitionTime
                               delay:0
                             options:UIViewAnimationOptionCurveEaseOut
                          animations:^{
-                             toViewController.view.transform = CGAffineTransformIdentity;
-                             toViewController.view.alpha = 1.0f;
-                             fromViewController.view.transform = CGAffineTransformMakeScale(1.0 - kRZPushScaleChangePct, 1.0 - kRZPushScaleChangePct);
+                             toView.transform = CGAffineTransformIdentity;
+                             toView.alpha = 1.0f;
+                             fromView.alpha = 0.0f;
+                             fromView.transform = CGAffineTransformMakeScale(1.0 - kRZPushScaleChangePct, 1.0 - kRZPushScaleChangePct);
                          }
                          completion:^(BOOL finished) {
-                             toViewController.view.transform = CGAffineTransformIdentity;
-                             fromViewController.view.transform = CGAffineTransformIdentity;
-                             toViewController.view.alpha = 1.0f;
+                             toView.transform = CGAffineTransformIdentity;
+                             fromView.transform = CGAffineTransformIdentity;
+                             toView.alpha = 1.0f;
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }

--- a/RZTransitions/Transitions/RZZoomPushAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomPushAnimationController.m
@@ -27,6 +27,7 @@
 //
 
 #import "RZZoomPushAnimationController.h"
+#import "NSObject+RZTransitionsViewHelpers.h"
 #import <UIKit/UIKit.h>
 
 #define kRZPushTransitionTime 0.35
@@ -38,8 +39,8 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {    
-    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
-    UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
+    UIView *toView = [(NSObject *)transitionContext rzt_toView];
+    UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *container = [transitionContext containerView];
     
     if ( self.isPositiveAnimation ) {

--- a/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.h
+++ b/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.h
@@ -1,0 +1,16 @@
+//
+//  NSObject+RZTransitionsViewHelpers.h
+//  RZTransitions-Demo
+//
+//  Created by Eric Slosser on 11/20/15.
+//  Copyright © 2015 Raizlabs. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface NSObject (RZTransitionsViewHelpers)
+
+- (UIView *)rzt_toView;
+- (UIView *)rzt_fromView;
+
+@end

--- a/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.m
+++ b/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.m
@@ -1,0 +1,45 @@
+//
+//  NSObject+RZTransitionsViewHelpers_h.m
+//  RZTransitions-Demo
+//
+//  Created by Eric Slosser on 11/20/15.
+//  Copyright © 2015 Raizlabs. All rights reserved.
+//
+
+#import "NSObject+RZTransitionsViewHelpers.h"
+
+@implementation NSObject (RZTransitionsViewHelpers)
+
+- (UIView *)rzt_toView
+{
+    return [self _RZTViewHelper:YES];
+}
+
+- (UIView *)rzt_fromView
+{
+    return [self _RZTViewHelper:NO];
+}
+
+- (UIView *)_RZTViewHelper:(BOOL)isTo
+{
+    NSAssert([self conformsToProtocol:@protocol(UIViewControllerContextTransitioning)], @"bad parameter");
+    if (![self conformsToProtocol:@protocol(UIViewControllerContextTransitioning)]) {
+        return nil;
+    }
+    id<UIViewControllerContextTransitioning> context = (id<UIViewControllerContextTransitioning>)self;
+
+    NSString *vcKey = isTo ? UITransitionContextToViewControllerKey : UITransitionContextFromViewControllerKey;
+    UIViewController *vc = [context viewControllerForKey:vcKey];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+    if ([context respondsToSelector:@selector(viewForKey:)]) {
+        NSString *vKey = isTo ? UITransitionContextToViewKey : UITransitionContextFromViewKey;
+        return [context viewForKey:vKey];
+    }
+    else {
+        return vc.view;
+    }
+#else
+    return vc.view;
+#endif
+}
+@end


### PR DESCRIPTION
- set 'toView.frame = container.frame'
- create -[NSObject rzt_toView] and -[NSObject rzt_fromView], to
 - factor the correct iOS7 vs. iOS8 behavior.
 - hide the shenanigans required to allow RZTransitions to be built on Xcode 6 or 7.