### PR TITLE
fix to ZoomPush animation's reverse direction.

### DIFF
--- a/RZTransitions/Transitions/RZZoomPushAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomPushAnimationController.m
@@ -64,7 +64,7 @@
                          }];
     }
     else {
-        if (transitionContext.presentationStyle == UIModalPresentationNone) {
+        if (transitionContext.presentationStyle == UIModalPresentationNone || transitionContext.presentationStyle == UIModalPresentationFullScreen) {
             [container insertSubview:toView belowSubview:fromView];
         }
         toView.transform = CGAffineTransformMakeScale(1.0 + kRZPushScaleChangePct, 1.0 + kRZPushScaleChangePct);


### PR DESCRIPTION
When reversing, insert the 'toView' when presentationStyle is 'none' OR 'full', not just 'none'.

Otherwise, the toView isn't seen until after the animation finishes.

fixes issue #41 