### PR TITLE
RZBaseSwipeInteractionController short circuits interactive transitions [#46]

### DIFF
--- a/RZTransitions/Interactors/RZBaseSwipeInteractionController.m
+++ b/RZTransitions/Interactors/RZBaseSwipeInteractionController.m
@@ -90,42 +90,35 @@
                 }
             }
             else {
-                if ( self.action & RZTransitionAction_Pop ) {
-                    [self cancelInteractiveTransition];
-                    self.isInteractive = NO;
+                if (self.action & RZTransitionAction_Pop) {
                     [self.fromViewController.navigationController popViewControllerAnimated:YES];
                 }
-                else if ( self.action & RZTransitionAction_Dismiss ) {
-                    [self cancelInteractiveTransition];
-                    self.isInteractive = NO;
+                else if (self.action & RZTransitionAction_Dismiss) {
                     [self.fromViewController dismissViewControllerAnimated:YES completion:nil];
                 }
             }
             break;
-            
+
         case UIGestureRecognizerStateChanged:
-            if ( self.isInteractive ) {
-                self.shouldCompleteTransition = ( percentage >= [self swipeCompletionPercent] );
+            if (self.isInteractive) {
+                self.shouldCompleteTransition = (percentage >= [self swipeCompletionPercent]);
                 [self updateInteractiveTransition:percentage];
             }
             break;
-            
+
         case UIGestureRecognizerStateCancelled:
-            self.isInteractive = NO;
-            [self cancelInteractiveTransition];
-            break;
-            
         case UIGestureRecognizerStateEnded:
-            if ( self.isInteractive ) {
-                self.isInteractive = NO;
-                if ( !self.shouldCompleteTransition || panGestureRecognizer.state == UIGestureRecognizerStateCancelled ) {
+            if (self.isInteractive) {
+                if (!self.shouldCompleteTransition) {
                     [self cancelInteractiveTransition];
                 }
                 else {
                     [self finishInteractiveTransition];
                 }
+
+                self.isInteractive = NO;
             }
-            
+
         default:
             break;
     }

--- a/RZTransitions/Transitions/RZCirclePushAnimationController.h
+++ b/RZTransitions/Transitions/RZCirclePushAnimationController.h
@@ -33,7 +33,7 @@
 
 @protocol RZCirclePushAnimationDelegate;
 
-@interface RZCirclePushAnimationController : RZZoomPushAnimationController <RZAnimationControllerProtocol>
+@interface RZCirclePushAnimationController : RZZoomPushAnimationController
 
 /**
  *  Animation delegate for controlling information about the circle transition.

--- a/RZTransitions/Transitions/RZCirclePushAnimationController.m
+++ b/RZTransitions/Transitions/RZCirclePushAnimationController.m
@@ -37,6 +37,8 @@
 
 @interface RZCirclePushAnimationController ()
 
+@property (weak, nonatomic) UIView *maskedView;
+
 - (CGPoint)circleCenterPointWithFromView:(UIView *)fromView;
 - (CGFloat)circleStartingRadiusWithFromView:(UIView *)fromView toView:(UIView *)toView;
 
@@ -60,6 +62,8 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {
+    [super animateTransition:transitionContext];
+
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
 
@@ -96,6 +100,7 @@
         toView.layer.mask = circleMaskLayer;
         toView.layer.masksToBounds = YES;
         [circleMaskLayer addAnimation:circleMaskAnimation forKey:kRZCircleMaskAnimation];
+        self.maskedView = toView;
     }
     else {
         [circleMaskAnimation setFillMode:kCAFillModeForwards];
@@ -108,9 +113,21 @@
         fromView.layer.mask = circleMaskLayer;
         fromView.layer.masksToBounds = YES;
         [circleMaskLayer addAnimation:circleMaskAnimation forKey:kRZCircleMaskAnimation];
+        self.maskedView = fromView;
     }
-    
-    [super animateTransition:transitionContext];
+}
+
+- (void)animationEnded:(BOOL)transitionCompleted
+{
+    // animationEnded: is a optional method of the UIViewControllerAnimatedTransitioning protocol.
+    // RZZoomPushAnimationController does not currently implement this method, but might at some point,
+    //  so make sure we are doing something sane here.
+    if ([[[self class] superclass] respondsToSelector:@selector(animationEnded:)]) {
+        [super animationEnded:transitionCompleted];
+    }
+
+    self.maskedView.layer.mask = nil;
+    self.maskedView = nil;
 }
 
 #pragma mark - Helper Methods


### PR DESCRIPTION
- Fixes an issue where RZBaseSwipeInteractionController was canceled as soon as the gesture started tracking
- Cleanup `RZCirclePushAnimationController` after the animation is completed. Fixes an issue where the modal *Present* animation would end up in a stuck state after canceling a transition.