### PR TITLE
fixes for https://github.com/Raizlabs/RZTransitions/issues/52

### DIFF
--- a/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
+++ b/RZTransitions-Demo/RZTransitions-Demo.xcodeproj/project.pbxproj
@@ -801,7 +801,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.raizlabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -817,7 +817,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.raizlabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/RZTransitions-Demo/RZTransitions-Demo/RZTransitions-Demo-Info.plist
+++ b/RZTransitions-Demo/RZTransitions-Demo/RZTransitions-Demo-Info.plist
@@ -33,6 +33,15 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>

--- a/RZTransitions/Transitions/RZCardSlideAnimationController.m
+++ b/RZTransitions/Transitions/RZCardSlideAnimationController.m
@@ -52,6 +52,7 @@
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
 
     UIView *bgView = [[UIView alloc] initWithFrame:container.bounds];
     bgView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -110,6 +111,8 @@
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZRectZoomAnimationController.m
+++ b/RZTransitions/Transitions/RZRectZoomAnimationController.m
@@ -58,6 +58,7 @@ static const CGFloat kRZRectZoomDefaultSpringVelocity     = 15.0f;
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
 
     CGRect originalFrame = fromView.frame;
     CGRect cellFrame = CGRectZero;
@@ -124,6 +125,8 @@ static const CGFloat kRZRectZoomDefaultSpringVelocity     = 15.0f;
                              }];
         }];
     }
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZSegmentControlMoveFadeAnimationController.m
+++ b/RZTransitions/Transitions/RZSegmentControlMoveFadeAnimationController.m
@@ -46,6 +46,7 @@
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     
     CGAffineTransform scaleTransform = CGAffineTransformMakeScale(kRZSegScaleAmount, kRZSegScaleAmount);
     CGAffineTransform oldTranslateTransform;
@@ -77,6 +78,7 @@
                          [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                      }];
 
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZShrinkZoomAnimationController.m
+++ b/RZTransitions/Transitions/RZShrinkZoomAnimationController.m
@@ -39,6 +39,7 @@
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
  
     [UIView animateWithDuration:0.5 delay:0 options:0 animations:^{
         [fromView setTransform:CGAffineTransformMakeScale(0.1, 0.1)];
@@ -55,6 +56,8 @@
         }];
         
     }];
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZZoomAlphaAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomAlphaAnimationController.m
@@ -44,6 +44,7 @@
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     
     toView.userInteractionEnabled = YES;
     
@@ -82,6 +83,8 @@
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZZoomBlurAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomBlurAnimationController.m
@@ -146,6 +146,8 @@ static char kRZZoomBlurImageAssocKey;
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext

--- a/RZTransitions/Transitions/RZZoomPushAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomPushAnimationController.m
@@ -42,6 +42,7 @@
     UIView *toView = [(NSObject *)transitionContext rzt_toView];
     UIView *fromView = [(NSObject *)transitionContext rzt_fromView];
     UIView *container = [transitionContext containerView];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     
     if ( self.isPositiveAnimation ) {
         toView.frame = container.frame;
@@ -86,6 +87,8 @@
                              [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
                          }];
     }
+    
+    toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
 }
 
 - (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext


### PR DESCRIPTION
Fixes for https://github.com/Raizlabs/RZTransitions/issues/52

- Added  ```toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];``` to the end of the ```- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext``` methods (in each of the transitions) as per [this](http://stackoverflow.com/a/32256538/3151873) SO.
- Updated the project settings in the Demo to build with multiple orientations (as well as iPad) enabled for testing.