### PR TITLE
Fix incorrect view height when transitioning with navigation controller

### DIFF
--- a/RZTransitions/Transitions/RZCardSlideAnimationController.m
+++ b/RZTransitions/Transitions/RZCardSlideAnimationController.m
@@ -60,7 +60,7 @@
 
     if ( self.isPositiveAnimation ) {
         [container insertSubview:toView belowSubview:fromView];
-        toView.frame = container.frame;
+        toView.frame = [(NSObject *)transitionContext rzt_toViewFinalFrame];
         toView.transform = CGAffineTransformMakeScale(1.0 - kRZSlideScaleChangePct, 1.0 - kRZSlideScaleChangePct);
         toView.alpha = 0.1f;
 

--- a/RZTransitions/Transitions/RZZoomPushAnimationController.m
+++ b/RZTransitions/Transitions/RZZoomPushAnimationController.m
@@ -44,8 +44,8 @@
     UIView *container = [transitionContext containerView];
     
     if ( self.isPositiveAnimation ) {
-        toView.frame = container.frame;
         [container insertSubview:toView belowSubview:fromView];
+        toView.frame = [(NSObject *)transitionContext rzt_toViewFinalFrame];
         toView.transform = CGAffineTransformMakeScale(1.0 - kRZPushScaleChangePct, 1.0 - kRZPushScaleChangePct);
 
         [UIView animateWithDuration:kRZPushTransitionTime

--- a/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.h
+++ b/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.h
@@ -12,5 +12,6 @@
 
 - (UIView *)rzt_toView;
 - (UIView *)rzt_fromView;
+- (CGRect)rzt_toViewFinalFrame;
 
 @end

--- a/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.m
+++ b/RZTransitions/Utilities/NSObject+RZTransitionsViewHelpers.m
@@ -20,6 +20,12 @@
     return [self _RZTViewHelper:NO];
 }
 
+- (CGRect)rzt_toViewFinalFrame
+{
+    id<UIViewControllerContextTransitioning> context = (id<UIViewControllerContextTransitioning>)self;
+    return [context finalFrameForViewController:[context viewControllerForKey:UITransitionContextToViewControllerKey]];
+}
+
 - (UIView *)_RZTViewHelper:(BOOL)isTo
 {
     NSAssert([self conformsToProtocol:@protocol(UIViewControllerContextTransitioning)], @"bad parameter");


### PR DESCRIPTION
Found a problem when using custom transitions with navigation controller, solved by following steps [here](https://stackoverflow.com/questions/20312765/navigation-controller-top-layout-guide-not-honored-with-custom-transition)